### PR TITLE
fix: handle unsequenced QQ authentication failures

### DIFF
--- a/src/common/emailNotification.ts
+++ b/src/common/emailNotification.ts
@@ -69,6 +69,11 @@ export class EmailNotificationService extends Service {
       this.onOffline(data.tipsDesc || data.tipsTitle)
     })
 
+    this.ctx.on('qq/session-expired', (reason) => {
+      wasOffline = true
+      this.onOffline(reason)
+    })
+
     this.checkLoginStatus = setInterval(() => {
       if (wasOffline && selfInfo.online) {
         this.notificationSent = false

--- a/src/main/qqProtocol/base.ts
+++ b/src/main/qqProtocol/base.ts
@@ -23,6 +23,8 @@ declare module 'cordis' {
     'qq/online': () => void
     /** 协议层断开（WS / TCP 掉了）。上层一般不需要卸插件，等协议层重连后会再次 emit `qq/online` */
     'protocol/disconnect': () => void
+    /** An online QQ session was rejected; notify consumers without applying KickNT recovery. */
+    'qq/session-expired': (reason: string) => void
     'llbot/self-nick-changed': (info: { nick: string }) => void
   }
 }

--- a/src/main/qqProtocol/direct-lib/client.ts
+++ b/src/main/qqProtocol/direct-lib/client.ts
@@ -756,6 +756,7 @@ export class DirectProtocolClient extends EventEmitter {
 
   async sendCommand(cmd: string, payload: Buffer, encryptType?: EncryptType, timeout = 15000): Promise<SsoPacket> {
     const seq = this.nextSeq()
+    const session = this.session
     const ctx = this.getPacketContext()
     const enc = encryptType ?? (this.session ? EncryptType.EncryptD2Key : EncryptType.EncryptEmpty)
 
@@ -784,6 +785,10 @@ export class DirectProtocolClient extends EventEmitter {
       }
     }
 
+    // Signing can still be in flight when another request invalidates the session.
+    if (this.session !== session) {
+      throw new Error('QQ session changed before the command could be sent')
+    }
     const packet = buildServicePacket(seq, cmd, ctx, payload, enc, signResult)
 
     // 调试用: 出网前 dump SSO frame, 跟真机抓包对照定位 sign 不一致的字节差异.
@@ -823,6 +828,22 @@ export class DirectProtocolClient extends EventEmitter {
     const parsed = parseServicePacket(frame, d2Key)
     if (!parsed) {
       this.emit('error', new Error('Failed to parse incoming packet'))
+      return
+    }
+    // Authentication failures can have seq=0 and no command, so handle them before request matching.
+    if (parsed.retCode === -10001 && this.session) {
+      const uin = this.session.uin
+      const error = new Error(
+        `QQ session authentication failed: retCode=${parsed.retCode}, ${parsed.extraMsg || 'Please log in again'}`,
+      )
+      this.clearSession()
+      for (const pending of this.pendingPackets.values()) {
+        clearTimeout(pending.timeout)
+        pending.reject(error)
+      }
+      this.pendingPackets.clear()
+      this.frameArriveAt.clear()
+      this.emit('session-expired', uin, error)
       return
     }
     if (isDebugEnabled()) this.frameArriveAt.set(parsed.seq, tArrive)

--- a/src/main/qqProtocol/direct-lib/login.ts
+++ b/src/main/qqProtocol/direct-lib/login.ts
@@ -209,6 +209,8 @@ export async function pollQrCode(client: DirectProtocolClient, sig: Buffer): Pro
 export async function loginWithQrResult(
   client: DirectProtocolClient,
   qrResult: QrPollResult,
+  // Checked after the network response, before installing session credentials.
+  isCurrent?: () => boolean,
 ): Promise<LoginResult> {
   if (!qrResult.tempPassword || !qrResult.tgtgtKey || !qrResult.noPicSig || !qrResult.uin) {
     throw new Error('QR poll result incomplete')
@@ -283,6 +285,8 @@ export async function loginWithQrResult(
     15000,
   )
 
+  // A superseded QR attempt must not install credentials into the shared client.
+  if (isCurrent && !isCurrent()) throw new Error('QR login attempt was superseded')
   const result = parseLoginResponse(resp.payload, client.getEcdhShareKey(), qrResult.tgtgtKey)
   if (result.success) {
     client.setSession({

--- a/src/main/qqProtocol/direct.ts
+++ b/src/main/qqProtocol/direct.ts
@@ -121,6 +121,7 @@ export class DirectQQProtocol extends QQProtocolBase {
 
   public async logout(): Promise<void> {
     this.manualLogout = true
+    this.qrPollToken++
     if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null }
     this.directClient?.clearSession()
     this.directClient?.disconnect()
@@ -253,13 +254,14 @@ export class DirectQQProtocol extends QQProtocolBase {
   private async doInitDirectClient(authToken: string): Promise<void> {
     this.manualLogout = false
     // 换账号 / 重试时取消上一轮残留的 QR poll loop (qrPollToken 变 -> 旧 poll 循环下一 tick 自退)
-    this.qrPollToken++
+    const myToken = ++this.qrPollToken
     // 换账号/重建 client: 清 base 展示缓存, 否则 TTL 内会复用上一账号的旧码
     this.resetQrState()
     this.directQrResult = null
 
     // native sign 已 init 时热切换到最新 token; 未 init (首次) 时 no-op, token 由 new client 的 config 带入
     await updateAuthToken(authToken).catch((e) => this.logger.warn('[Sign] updateAuthToken failed:', (e as Error).message))
+    if (this.qrPollToken !== myToken) return
 
     // 先 loadSession 拿 (uin, guid). 运行时 override 优先于 argv -q.
     const specifiedUin = this.runtimeUinOverride || getSpecifiedUin()
@@ -308,11 +310,13 @@ export class DirectQQProtocol extends QQProtocolBase {
       // uin 授权/绑定由服务端判 (登录时按配额自动绑, 满了才 403); 本地不预检 allowed_uins.
       this.logger.info('Found saved session for UIN %s (file: %s), attempting restore...', persisted.uin, getSessionFilePathForUin(persisted.uin))
       if (!this.directClient.isConnected) await this.directClient.connect()
+      if (this.qrPollToken !== myToken) return
       const session = persistedToSessionInfo(persisted)
       this.directClient.setSession(session)
 
       try {
         await registerOnline(this.directClient)
+        if (this.qrPollToken !== myToken || this.directClient.getSession() !== session) return
         this.logger.info('[QQ Server] Online registered!')
         selfInfo.uin = persisted.uin
         selfInfo.uid = persisted.uid
@@ -323,9 +327,12 @@ export class DirectQQProtocol extends QQProtocolBase {
         this.directStopHeartbeat = startHeartbeat(this.directClient)
         this.maybeEmitOnline()
         // 直连 session 恢复后 nick 可能为空; 异步补查
-        if (!selfInfo.nick) this.scheduleFetchSelfNick()
+        if (!selfInfo.nick) {
+          this.scheduleFetchSelfNick(() => this.qrPollToken === myToken && this.directClient?.getSession() === session)
+        }
         return
       } catch (e) {
+        if (this.qrPollToken !== myToken || this.directClient.getSession() !== session) return
         // 恢复失败 (session 过期): 清 session, 但保留 TCP 连接复用给扫码 -- 不 disconnect, 否则会触发
         // close 事件且 native sign relay 目标断链, 下面 fresh 分支直接用现连接拉码.
         this.logger.info('Saved session expired, will need QR login: %s', (e as Error).message)
@@ -361,7 +368,10 @@ export class DirectQQProtocol extends QQProtocolBase {
       this.directPollResult = null
       this.resetQrState()
       setLoginState({ state: 'need_qrcode', qrcode_png_base64: undefined })
-      if (wasOnline) this.ctx.parallel('protocol/disconnect')
+      if (wasOnline) {
+        this.ctx.parallel('protocol/disconnect')
+        this.ctx.parallel('qq/session-expired', error.message)
+      }
       this.ensureQrLoop()
     })
     client.on('error', (err: Error) => {
@@ -388,8 +398,8 @@ export class DirectQQProtocol extends QQProtocolBase {
       }
     })
     client.on('push', (packet: { cmd: string; payload: Buffer }) => {
-      // 收到包 = 连着; 顺带刷新 lastConnectedTime
-      this.lastConnectedTime = Date.now()
+      // Unauthenticated traffic must not postpone the disconnect notification.
+      if (client.isLoggedIn) this.lastConnectedTime = Date.now()
       this.ctx.parallel('qq/raw', { cmd: packet.cmd, payload: packet.payload })
     })
   }
@@ -411,7 +421,7 @@ export class DirectQQProtocol extends QQProtocolBase {
         this.directPollResult = result
 
         if (result.state === QrCodeState.Confirmed) {
-          await this.completeDirectLogin()
+          await this.completeDirectLogin(myToken)
           return
         }
 
@@ -427,6 +437,7 @@ export class DirectQQProtocol extends QQProtocolBase {
           return
         }
       } catch (e) {
+        if (this.qrPollToken !== myToken) return
         this.logger.warn('QR poll error:', (e as Error).message)
       }
 
@@ -437,20 +448,25 @@ export class DirectQQProtocol extends QQProtocolBase {
     setTimeout(poll, 2000)
   }
 
-  private async completeDirectLogin() {
-    if (!this.directClient || !this.directPollResult || !this.directQrResult) return
+  private async completeDirectLogin(myToken: number) {
+    const client = this.directClient
+    const pollResult = this.directPollResult
+    const qrResult = this.directQrResult
+    if (this.qrPollToken !== myToken || !client || !pollResult || !qrResult) return
     this.manualLogout = false
 
     // Get UIN
-    const urlParams = new URL(this.directQrResult.url).searchParams
+    const urlParams = new URL(qrResult.url).searchParams
     const qrSig = urlParams.get('k') || ''
     const uin = await getCorrectUin(AppInfo.appId, qrSig)
-    this.directPollResult.uin = String(uin)
+    if (this.qrPollToken !== myToken) return
+    pollResult.uin = String(uin)
 
     // uin 授权/绑定由服务端判 (登录时按配额自动绑, 满了才 403); 本地不预检 allowed_uins.
 
     // wtlogin.login
-    const loginResult = await loginWithQrResult(this.directClient, this.directPollResult)
+    const loginResult = await loginWithQrResult(client, pollResult, () => this.qrPollToken === myToken)
+    if (this.qrPollToken !== myToken) return
     if (!loginResult.success) {
       this.logger.error(`Login failed: state=${loginResult.state} ${loginResult.tag} ${loginResult.message}`)
       // 登录失败原因回传 WebUI (如 auth_token 可用 QQ 数量已达上限)
@@ -458,27 +474,30 @@ export class DirectQQProtocol extends QQProtocolBase {
       return
     }
 
-    this.logger.info(`Login successful! UID: ${loginResult.uid}, nick: "${loginResult.nick}"`)
-
-    // Save session
-    const session = this.directClient.getSession()!
-    saveSession(session, this.directPollResult.tgtgtKey!, this.directClient.getGuid(), loginResult.tempPassword, loginResult.nick)
+    const session = client.getSession()
+    if (!session) return
 
     // Register online: 失败视为登录未完成, 不标记在线, 报错回 WebUI. 必须清掉半成品 session
     // (loginWithQrResult 已 setSession -> isLoggedIn=true), 否则扫码 loop 认为已登录会停, 不出新码,
     // 变成收不到 MsgPush 的"假在线". 连接保留复用, 下一轮 loop 直接拉新码.
     try {
-      await registerOnline(this.directClient)
+      await registerOnline(client)
     } catch (e) {
+      if (this.qrPollToken !== myToken || client.getSession() !== session) return
       const msg = (e as Error).message
       this.logger.error('Register online failed:', msg)
       authTokenStatus.loginError = `上线注册失败: ${msg}`
-      this.directClient.clearSession()
+      client.clearSession()
       return
     }
+    // A completed request may resume after invalidation or a newer login attempt.
+    if (this.qrPollToken !== myToken || client.getSession() !== session) return
+
+    this.logger.info(`Login successful! UID: ${loginResult.uid}, nick: "${loginResult.nick}"`)
+    saveSession(session, pollResult.tgtgtKey!, client.getGuid(), loginResult.tempPassword, loginResult.nick)
 
     // Start heartbeat
-    this.directStopHeartbeat = startHeartbeat(this.directClient)
+    this.directStopHeartbeat = startHeartbeat(client)
 
     // Update global state
     selfInfo.uin = String(uin)
@@ -488,6 +507,8 @@ export class DirectQQProtocol extends QQProtocolBase {
     // 记住已登录 uin: 断线重连走 initDirectClient() 时用它 loadSession 快速登录, 不退回扫码.
     this.runtimeUinOverride = String(uin)
     this.maybeEmitOnline()
-    if (!selfInfo.nick) this.scheduleFetchSelfNick()
+    if (!selfInfo.nick) {
+      this.scheduleFetchSelfNick(() => this.qrPollToken === myToken && client.getSession() === session)
+    }
   }
 }

--- a/src/main/qqProtocol/direct.ts
+++ b/src/main/qqProtocol/direct.ts
@@ -339,6 +339,31 @@ export class DirectQQProtocol extends QQProtocolBase {
 
   /** 给 client 挂事件 (error/connected/close/push). 只在首次建立 client 时调一次 -- 复用 client 不重挂. */
   private bindDirectClientEvents(client: DirectProtocolClient): void {
+    client.on('session-expired', (uin: string, error: Error) => {
+      const wasOnline = this.onlineEmitted
+      selfInfo.online = false
+      this.onlineEmitted = false
+      authTokenStatus.loginError = error.message
+      this.logger.warn('QQ session expired:', error.message)
+      if (this.directStopHeartbeat) {
+        this.directStopHeartbeat()
+        this.directStopHeartbeat = null
+      }
+      if (this.reconnectTimer) {
+        clearTimeout(this.reconnectTimer)
+        this.reconnectTimer = null
+      }
+      // Remove only the rejected account's credentials; retain the device identity and native client.
+      deleteSession(uin)
+      this.runtimeUinOverride = null
+      this.qrPollToken++
+      this.directQrResult = null
+      this.directPollResult = null
+      this.resetQrState()
+      setLoginState({ state: 'need_qrcode', qrcode_png_base64: undefined })
+      if (wasOnline) this.ctx.parallel('protocol/disconnect')
+      this.ensureQrLoop()
+    })
     client.on('error', (err: Error) => {
       this.logger.warn('Direct client error:', err.message)
     })

--- a/src/milky/adapter.ts
+++ b/src/milky/adapter.ts
@@ -319,6 +319,10 @@ export class MilkyAdapter extends Service {
         this.emitEvent('bot_offline', eventData)
       }
     })
+
+    this.ctx.on('qq/session-expired', (reason) => {
+      this.emitEvent('bot_offline', { reason })
+    })
   }
 }
 

--- a/test/unit/qqProtocol/directSession.test.ts
+++ b/test/unit/qqProtocol/directSession.test.ts
@@ -1,0 +1,288 @@
+import { EventEmitter } from 'node:events'
+import { Context } from 'cordis'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { authTokenStatus, selfInfo } from '@/common/globalVars'
+import { DirectQQProtocol } from '../../../src/main/qqProtocol/direct'
+import { DirectProtocolClient, type SessionInfo } from '../../../src/main/qqProtocol/direct-lib/client'
+import { fetchQrCode } from '../../../src/main/qqProtocol/direct-lib/login'
+import { deleteMachineGuid } from '../../../src/main/qqProtocol/direct-lib/machineGuid'
+import { deleteSession } from '../../../src/main/qqProtocol/direct-lib/session'
+import { requestSign } from '../../../src/main/qqProtocol/direct-lib/sign'
+import { teaEncrypt } from '../../../src/main/qqProtocol/direct-lib/tea'
+import { getCurrentLoginState } from '../../../src/main/llbot-ipc'
+
+vi.mock('@/common/globalVars', () => ({
+  selfInfo: { uin: '123456', uid: 'test-uid', nick: 'TestBot', online: true },
+  authTokenStatus: { loginError: '' },
+  TEMP_DIR: '/tmp/test-data/temp',
+}))
+
+vi.mock('@/main/config', () => ({
+  authTokenUtil: { reload: vi.fn(() => 'test-auth-token') },
+}))
+
+vi.mock('@/main/qqProtocol/direct-lib/authTokenWatcher', () => ({
+  startAuthTokenWatcher: vi.fn(),
+}))
+
+vi.mock('@/main/qqProtocol/direct-lib/machineGuid', () => ({
+  loadMachineGuidSync: vi.fn(() => Buffer.alloc(16)),
+  overwriteMachineGuid: vi.fn(),
+  deleteMachineGuid: vi.fn(),
+}))
+
+vi.mock('@/main/qqProtocol/direct-lib/session', () => ({
+  saveSession: vi.fn(),
+  loadSession: vi.fn(),
+  deleteSession: vi.fn(),
+  listAvailableSessions: vi.fn(() => []),
+  persistedToSessionInfo: vi.fn(),
+  getSpecifiedUin: vi.fn(() => '123456'),
+  getSessionFilePathForUin: vi.fn(),
+}))
+
+vi.mock('@/main/qqProtocol/direct-lib/sign', () => ({
+  requestSign: vi.fn(),
+  setupSign: vi.fn(),
+  setSignMachineGuid: vi.fn(),
+  acquireSignToken: vi.fn(async () => ({ token: 'test-token', ttlSecs: 3600 })),
+  updateAuthToken: vi.fn(),
+}))
+
+vi.mock('@/main/qqProtocol/direct-lib/login', () => ({
+  fetchQrCode: vi.fn(),
+  pollQrCode: vi.fn(),
+  loginWithQrResult: vi.fn(),
+  getCorrectUin: vi.fn(),
+  QrCodeState: { Confirmed: 0, WaitingForConfirm: 53, Expired: 17, Cancelled: 54 },
+}))
+
+vi.mock('@/main/qqProtocol/direct-lib/connection', () => ({
+  TcpConnection: class extends EventEmitter {
+    isConnected = true
+    send = vi.fn()
+    connect = vi.fn(async () => {
+      this.isConnected = true
+    })
+    disconnect = vi.fn(() => {
+      this.isConnected = false
+      this.emit('close')
+    })
+  },
+}))
+
+function createSession(): SessionInfo {
+  return {
+    uin: '123456',
+    uid: 'test-uid',
+    d2: Buffer.alloc(16),
+    d2Key: Buffer.alloc(16),
+    tgt: Buffer.alloc(16),
+    a2: Buffer.alloc(16),
+    a2Key: Buffer.alloc(16),
+    sKey: Buffer.alloc(0),
+  }
+}
+
+function int32(value: number): Buffer {
+  const data = Buffer.alloc(4)
+  data.writeInt32BE(value)
+  return data
+}
+
+// Synthetic protocol-12 responses exercise the real parser without account credentials or captured traffic.
+function responseFrame(seq: number, retCode = 0, cmd = 'test.command', extraMsg = ''): Buffer {
+  const extra = Buffer.from(extraMsg)
+  const command = Buffer.from(cmd)
+  const head = Buffer.concat([
+    int32(seq),
+    int32(retCode),
+    int32(extra.length + 4),
+    extra,
+    int32(command.length + 4),
+    command,
+  ])
+  const body = Buffer.concat([int32(head.length + 4), head, int32(4)])
+  return Buffer.concat([int32(12), Buffer.from([2, 0]), int32(4), Buffer.from(teaEncrypt(body, Buffer.alloc(16)))])
+}
+
+const authMessage = '身份验证失败，请你重新登录。(s20)'
+
+describe('direct session authentication failures', () => {
+  let client: DirectProtocolClient
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    client = new DirectProtocolClient()
+    client.setSession(createSession())
+    selfInfo.online = true
+    authTokenStatus.loginError = ''
+  })
+
+  afterEach(() => {
+    client.disconnect()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it.each(['unmatched', 'matched'])('invalidates the session for an %s authentication failure', async (kind) => {
+    const expired = vi.fn()
+    const pushed = vi.fn()
+    client.on('session-expired', expired)
+    client.on('push', pushed)
+    const seq = client['seq']
+    const requests = Promise.allSettled([
+      client.sendCommand('test.command', Buffer.alloc(0)),
+      client.sendCommand('test.other', Buffer.alloc(0)),
+    ])
+
+    client['conn'].emit('packet', responseFrame(kind === 'matched' ? seq : 0, -10001, '', authMessage))
+
+    const results = await requests
+    for (const result of results) {
+      expect(result.status).toBe('rejected')
+      if (result.status === 'rejected') expect(result.reason.message).toContain(authMessage)
+    }
+    expect(client.isLoggedIn).toBe(false)
+    expect(expired).toHaveBeenCalledExactlyOnceWith('123456', expect.any(Error))
+    expect(pushed).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('invalidates an idle session even when there are no pending requests', () => {
+    const expired = vi.fn()
+    client.on('session-expired', expired)
+    client['conn'].emit('packet', responseFrame(0, -10001, '', authMessage))
+    client['conn'].emit('packet', responseFrame(0, -10001, '', authMessage))
+    expect(expired).toHaveBeenCalledTimes(1)
+    expect(client.isLoggedIn).toBe(false)
+  })
+
+  it('keeps ordinary request errors scoped to the matching request', async () => {
+    const expired = vi.fn()
+    client.on('session-expired', expired)
+    const seq = client['seq']
+    const first = client.sendCommand('test.command', Buffer.alloc(0))
+    const rejected = expect(first).rejects.toThrow('retCode=-2')
+    const second = client.sendCommand('test.other', Buffer.alloc(0))
+
+    client['conn'].emit('packet', responseFrame(seq, -2, 'test.command', 'Request failed'))
+    client['conn'].emit('packet', responseFrame(seq + 1, 0, 'test.other'))
+
+    await rejected
+    await expect(second).resolves.toMatchObject({ cmd: 'test.other', retCode: 0 })
+    expect(client.isLoggedIn).toBe(true)
+    expect(expired).not.toHaveBeenCalled()
+  })
+
+  it('continues forwarding ordinary unsolicited pushes', () => {
+    const pushed = vi.fn()
+    client.on('push', pushed)
+    client['conn'].emit('packet', responseFrame(0, 0, 'trpc.msg.olpush.OlPushService.MsgPush'))
+    expect(pushed).toHaveBeenCalledWith(expect.objectContaining({ cmd: 'trpc.msg.olpush.OlPushService.MsgPush' }))
+    expect(client.isLoggedIn).toBe(true)
+  })
+
+  it('does not send a command whose signing finishes after session invalidation', async () => {
+    client.setAuthToken('test-auth-token')
+    const session = client.getSession()!
+    session.signToken12B = 'test-token'
+    session.signTokenExpiresAt = Date.now() + 60_000
+    let finishSign!: (result: { sign: Buffer; token: Buffer; extra: Buffer }) => void
+    vi.mocked(requestSign).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishSign = resolve
+        }),
+    )
+    const request = client.sendCommand('MessageSvc.PbSendMsg', Buffer.alloc(0))
+    const rejected = expect(request).rejects.toThrow('QQ session changed')
+    await vi.waitFor(() => expect(requestSign).toHaveBeenCalled())
+
+    client['conn'].emit('packet', responseFrame(0, -10001, '', authMessage))
+    finishSign({ sign: Buffer.alloc(0), token: Buffer.from('test-token'), extra: Buffer.alloc(0) })
+
+    await rejected
+    expect(client['conn'].send).not.toHaveBeenCalled()
+  })
+
+  it.each([true, false])('exposes a fresh QR login after invalidation (already online: %s)', async (alreadyOnline) => {
+    const ctx = new Context()
+    const protocol = new DirectQQProtocol(ctx)
+    protocol['directClient'] = client
+    protocol['onlineEmitted'] = alreadyOnline
+    selfInfo.online = alreadyOnline
+    protocol['runtimeUinOverride'] = '123456'
+    protocol['qrResult'] = { qrcodeUrl: 'stale', pngBase64: '', expireTimeSec: 180, sig: 'stale' }
+    protocol['qrFetchedAt'] = Date.now()
+    const stopHeartbeat = vi.fn()
+    protocol['directStopHeartbeat'] = stopHeartbeat
+    const reconnect = vi.fn()
+    protocol['reconnectTimer'] = setTimeout(reconnect, 5000) as unknown as NodeJS.Timeout
+    const disconnect = vi.fn()
+    ctx.on('protocol/disconnect', disconnect)
+    const qrLoop = vi
+      .spyOn(protocol as unknown as { ensureQrLoop(): void }, 'ensureQrLoop')
+      .mockImplementation(() => {})
+    protocol['bindDirectClientEvents'](client)
+    const seq = client['seq']
+    const pending = protocol.sendPB('test.command', Buffer.alloc(0))
+    const rejected = expect(pending).rejects.toThrow(authMessage)
+
+    client['conn'].emit('packet', responseFrame(0, -10001, '', authMessage))
+
+    await rejected
+    expect(selfInfo.online).toBe(false)
+    expect(protocol.get_is_connected()).toBe(false)
+    expect(authTokenStatus.loginError).toContain(authMessage)
+    expect(deleteSession).toHaveBeenCalledExactlyOnceWith('123456')
+    expect(deleteMachineGuid).not.toHaveBeenCalled()
+    expect(stopHeartbeat).toHaveBeenCalledTimes(1)
+    expect(disconnect).toHaveBeenCalledTimes(alreadyOnline ? 1 : 0)
+    expect(qrLoop).toHaveBeenCalledTimes(1)
+    expect(getCurrentLoginState()).toMatchObject({ state: 'need_qrcode' })
+    expect(client['conn'].disconnect).not.toHaveBeenCalled()
+    await expect(protocol.sendPB('test.command', Buffer.alloc(0))).rejects.toThrow('not logged in')
+
+    // A late reply must not restore the expired session or report the account online.
+    client['conn'].emit('packet', responseFrame(seq))
+    expect(selfInfo.online).toBe(false)
+    vi.mocked(fetchQrCode).mockResolvedValue({
+      url: 'fresh-qr',
+      image: Buffer.alloc(0),
+      sig: Buffer.alloc(16),
+      tgtgtKey: Buffer.alloc(16),
+    })
+    await expect(protocol.getLoginQrCode()).resolves.toMatchObject({ qrcodeUrl: 'fresh-qr' })
+    expect(fetchQrCode).toHaveBeenCalledWith(client)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(reconnect).not.toHaveBeenCalled()
+
+    // A replacement session can use the same client and report online again.
+    client.setSession(createSession())
+    selfInfo.online = true
+    const online = vi.fn()
+    ctx.on('qq/online', online)
+    protocol['maybeEmitOnline']()
+    expect(online).toHaveBeenCalledTimes(1)
+    expect(authTokenStatus.loginError).toBe('')
+  })
+
+  it('preserves saved credentials on an ordinary transport close', () => {
+    const ctx = new Context()
+    const protocol = new DirectQQProtocol(ctx)
+    protocol['directClient'] = client
+    protocol['onlineEmitted'] = true
+    protocol['bindDirectClientEvents'](client)
+    const reconnect = vi
+      .spyOn(protocol as unknown as { scheduleReconnect(): void }, 'scheduleReconnect')
+      .mockImplementation(() => {})
+
+    client['conn'].emit('close')
+
+    expect(selfInfo.online).toBe(false)
+    expect(deleteSession).not.toHaveBeenCalled()
+    expect(reconnect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/unit/qqProtocol/directSession.test.ts
+++ b/test/unit/qqProtocol/directSession.test.ts
@@ -4,10 +4,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { authTokenStatus, selfInfo } from '@/common/globalVars'
 import { DirectQQProtocol } from '../../../src/main/qqProtocol/direct'
 import { DirectProtocolClient, type SessionInfo } from '../../../src/main/qqProtocol/direct-lib/client'
-import { fetchQrCode } from '../../../src/main/qqProtocol/direct-lib/login'
+import {
+  fetchQrCode,
+  getCorrectUin,
+  loginWithQrResult,
+  pollQrCode,
+  type LoginResult,
+} from '../../../src/main/qqProtocol/direct-lib/login'
 import { deleteMachineGuid } from '../../../src/main/qqProtocol/direct-lib/machineGuid'
-import { deleteSession } from '../../../src/main/qqProtocol/direct-lib/session'
-import { requestSign } from '../../../src/main/qqProtocol/direct-lib/sign'
+import { registerOnline, startHeartbeat } from '../../../src/main/qqProtocol/direct-lib/online'
+import {
+  deleteSession,
+  loadSession,
+  persistedToSessionInfo,
+  saveSession,
+} from '../../../src/main/qqProtocol/direct-lib/session'
+import { requestSign, updateAuthToken } from '../../../src/main/qqProtocol/direct-lib/sign'
 import { teaEncrypt } from '../../../src/main/qqProtocol/direct-lib/tea'
 import { getCurrentLoginState } from '../../../src/main/llbot-ipc'
 
@@ -55,6 +67,11 @@ vi.mock('@/main/qqProtocol/direct-lib/login', () => ({
   loginWithQrResult: vi.fn(),
   getCorrectUin: vi.fn(),
   QrCodeState: { Confirmed: 0, WaitingForConfirm: 53, Expired: 17, Cancelled: 54 },
+}))
+
+vi.mock('@/main/qqProtocol/direct-lib/online', () => ({
+  registerOnline: vi.fn(async () => 'ok'),
+  startHeartbeat: vi.fn(() => vi.fn()),
 }))
 
 vi.mock('@/main/qqProtocol/direct-lib/connection', () => ({
@@ -107,6 +124,25 @@ function responseFrame(seq: number, retCode = 0, cmd = 'test.command', extraMsg 
 }
 
 const authMessage = '身份验证失败，请你重新登录。(s20)'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const loginSuccess: LoginResult = {
+  success: true,
+  ...createSession(),
+  tempPassword: Buffer.alloc(16),
+  nick: 'TestBot',
+  age: 0,
+  gender: 0,
+}
 
 describe('direct session authentication failures', () => {
   let client: DirectProtocolClient
@@ -222,6 +258,8 @@ describe('direct session authentication failures', () => {
     protocol['reconnectTimer'] = setTimeout(reconnect, 5000) as unknown as NodeJS.Timeout
     const disconnect = vi.fn()
     ctx.on('protocol/disconnect', disconnect)
+    const offline = vi.fn()
+    ctx.on('qq/session-expired', offline)
     const qrLoop = vi
       .spyOn(protocol as unknown as { ensureQrLoop(): void }, 'ensureQrLoop')
       .mockImplementation(() => {})
@@ -240,6 +278,8 @@ describe('direct session authentication failures', () => {
     expect(deleteMachineGuid).not.toHaveBeenCalled()
     expect(stopHeartbeat).toHaveBeenCalledTimes(1)
     expect(disconnect).toHaveBeenCalledTimes(alreadyOnline ? 1 : 0)
+    expect(offline).toHaveBeenCalledTimes(alreadyOnline ? 1 : 0)
+    if (alreadyOnline) expect(offline).toHaveBeenCalledWith(expect.stringContaining(authMessage))
     expect(qrLoop).toHaveBeenCalledTimes(1)
     expect(getCurrentLoginState()).toMatchObject({ state: 'need_qrcode' })
     expect(client['conn'].disconnect).not.toHaveBeenCalled()
@@ -284,5 +324,215 @@ describe('direct session authentication failures', () => {
     expect(selfInfo.online).toBe(false)
     expect(deleteSession).not.toHaveBeenCalled()
     expect(reconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['uin', 'login', 'register'] as const)('abandons QR completion invalidated during %s', async (stage) => {
+    const protocol = new DirectQQProtocol(new Context())
+    protocol['directClient'] = client
+    protocol['qrPollToken'] = 1
+    protocol['directQrResult'] = {
+      url: 'https://example.com/qr?k=test',
+      image: Buffer.alloc(0),
+      sig: Buffer.alloc(16),
+      tgtgtKey: Buffer.alloc(16),
+    }
+    protocol['directPollResult'] = { state: 0, tgtgtKey: Buffer.alloc(16) }
+    selfInfo.online = false
+    vi.spyOn(protocol as unknown as { ensureQrLoop(): void }, 'ensureQrLoop').mockImplementation(() => {})
+    protocol['bindDirectClientEvents'](client)
+    const uin = deferred<number>()
+    const login = deferred<LoginResult>()
+    const registration = deferred<string>()
+    vi.mocked(getCorrectUin).mockReturnValue(stage === 'uin' ? uin.promise : Promise.resolve(123456))
+    vi.mocked(loginWithQrResult).mockReturnValue(stage === 'login' ? login.promise : Promise.resolve(loginSuccess))
+    vi.mocked(registerOnline).mockReturnValue(registration.promise)
+    const completion = protocol['completeDirectLogin'](1)
+    if (stage === 'login') await vi.waitFor(() => expect(loginWithQrResult).toHaveBeenCalled())
+    if (stage === 'register') await vi.waitFor(() => expect(registerOnline).toHaveBeenCalled())
+
+    client['conn'].emit('packet', responseFrame(0, -10001, '', authMessage))
+    uin.resolve(123456)
+    login.resolve(loginSuccess)
+    registration.resolve('ok')
+    await completion
+
+    expect(client.isLoggedIn).toBe(false)
+    expect(selfInfo.online).toBe(false)
+    expect(protocol['onlineEmitted']).toBe(false)
+    expect(saveSession).not.toHaveBeenCalled()
+    expect(startHeartbeat).not.toHaveBeenCalled()
+    expect(authTokenStatus.loginError).toContain(authMessage)
+    expect(getCurrentLoginState()).toMatchObject({ state: 'need_qrcode' })
+  })
+
+  it('does not let a late registration failure clear a replacement session', async () => {
+    const protocol = new DirectQQProtocol(new Context())
+    protocol['directClient'] = client
+    protocol['qrPollToken'] = 1
+    protocol['directQrResult'] = {
+      url: 'https://example.com/qr?k=test',
+      image: Buffer.alloc(0),
+      sig: Buffer.alloc(16),
+      tgtgtKey: Buffer.alloc(16),
+    }
+    protocol['directPollResult'] = { state: 0, tgtgtKey: Buffer.alloc(16) }
+    selfInfo.online = false
+    vi.spyOn(protocol as unknown as { ensureQrLoop(): void }, 'ensureQrLoop').mockImplementation(() => {})
+    protocol['bindDirectClientEvents'](client)
+    vi.mocked(getCorrectUin).mockResolvedValue(123456)
+    vi.mocked(loginWithQrResult).mockResolvedValue(loginSuccess)
+    const registration = deferred<string>()
+    vi.mocked(registerOnline).mockReturnValue(registration.promise)
+    const completion = protocol['completeDirectLogin'](1)
+    await vi.waitFor(() => expect(registerOnline).toHaveBeenCalled())
+
+    client['conn'].emit('packet', responseFrame(0, -10001, '', authMessage))
+    const replacement = createSession()
+    client.setSession(replacement)
+    selfInfo.online = true
+    authTokenStatus.loginError = ''
+    registration.reject(new Error('Old registration failed'))
+    await completion
+
+    expect(client.getSession()).toBe(replacement)
+    expect(selfInfo.online).toBe(true)
+    expect(authTokenStatus.loginError).toBe('')
+    expect(saveSession).not.toHaveBeenCalled()
+    expect(startHeartbeat).not.toHaveBeenCalled()
+  })
+
+  it.each([false, true])('guards saved-session registration after invalidation (late failure: %s)', async (fails) => {
+    const protocol = new DirectQQProtocol(new Context())
+    protocol['directClient'] = client
+    selfInfo.online = false
+    vi.spyOn(protocol as unknown as { ensureQrLoop(): void }, 'ensureQrLoop').mockImplementation(() => {})
+    protocol['bindDirectClientEvents'](client)
+    vi.mocked(updateAuthToken).mockResolvedValue(undefined)
+    vi.mocked(loadSession).mockReturnValue({
+      uin: '123456',
+      uid: 'test-uid',
+      guid: Buffer.alloc(16).toString('hex'),
+      savedAt: 0,
+    })
+    vi.mocked(persistedToSessionInfo).mockReturnValue(createSession())
+    const registration = deferred<string>()
+    vi.mocked(registerOnline).mockReturnValue(registration.promise)
+    const completion = protocol['doInitDirectClient']('test-auth-token')
+    await vi.waitFor(() => expect(registerOnline).toHaveBeenCalled())
+
+    client['conn'].emit('packet', responseFrame(0, -10001, '', authMessage))
+    const replacement = createSession()
+    client.setSession(replacement)
+    if (fails) registration.reject(new Error('Old registration failed'))
+    else registration.resolve('ok')
+    await completion
+
+    expect(client.getSession()).toBe(replacement)
+    expect(selfInfo.online).toBe(false)
+    expect(startHeartbeat).not.toHaveBeenCalled()
+    expect(authTokenStatus.loginError).toContain(authMessage)
+  })
+
+  it('still saves and announces a current QR login after registration succeeds', async () => {
+    const ctx = new Context()
+    const protocol = new DirectQQProtocol(ctx)
+    protocol['directClient'] = client
+    protocol['qrPollToken'] = 1
+    protocol['directQrResult'] = {
+      url: 'https://example.com/qr?k=test',
+      image: Buffer.alloc(0),
+      sig: Buffer.alloc(16),
+      tgtgtKey: Buffer.alloc(16),
+    }
+    protocol['directPollResult'] = { state: 0, tgtgtKey: Buffer.alloc(16) }
+    selfInfo.online = false
+    client.clearSession()
+    vi.mocked(pollQrCode).mockResolvedValue(protocol['directPollResult'])
+    vi.mocked(getCorrectUin).mockResolvedValue(123456)
+    vi.mocked(loginWithQrResult).mockImplementation(async () => {
+      client.setSession(createSession())
+      return loginSuccess
+    })
+    const registration = deferred<string>()
+    vi.mocked(registerOnline).mockReturnValue(registration.promise)
+    const online = vi.fn()
+    ctx.on('qq/online', online)
+    protocol['startDirectQrPolling']()
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.waitFor(() => expect(registerOnline).toHaveBeenCalled())
+    expect(saveSession).not.toHaveBeenCalled()
+    registration.resolve('ok')
+    await vi.waitFor(() => expect(online).toHaveBeenCalledTimes(1))
+    expect(saveSession).toHaveBeenCalledTimes(1)
+    expect(startHeartbeat).toHaveBeenCalledExactlyOnceWith(client)
+    expect(online).toHaveBeenCalledTimes(1)
+    expect(selfInfo.online).toBe(true)
+  })
+
+  it('cancels QR completion on logout even before a session has been installed', async () => {
+    const protocol = new DirectQQProtocol(new Context())
+    protocol['directClient'] = client
+    protocol['qrPollToken'] = 1
+    protocol['directQrResult'] = {
+      url: 'https://example.com/qr?k=test',
+      image: Buffer.alloc(0),
+      sig: Buffer.alloc(16),
+      tgtgtKey: Buffer.alloc(16),
+    }
+    protocol['directPollResult'] = { state: 0, tgtgtKey: Buffer.alloc(16) }
+    selfInfo.online = false
+    client.clearSession()
+    vi.spyOn(protocol as unknown as { ensureQrLoop(): void }, 'ensureQrLoop').mockImplementation(() => {})
+    const uin = deferred<number>()
+    vi.mocked(getCorrectUin).mockReturnValue(uin.promise)
+    const completion = protocol['completeDirectLogin'](1)
+    await protocol.logout()
+    uin.resolve(123456)
+    await completion
+    expect(loginWithQrResult).not.toHaveBeenCalled()
+    expect(saveSession).not.toHaveBeenCalled()
+    expect(selfInfo.online).toBe(false)
+  })
+
+  it('rejects a superseded login response before it can install credentials', async () => {
+    const { loginWithQrResult: realLogin } = await vi.importActual<
+      typeof import('../../../src/main/qqProtocol/direct-lib/login')
+    >('../../../src/main/qqProtocol/direct-lib/login')
+    client.clearSession()
+    const response = deferred<Awaited<ReturnType<DirectProtocolClient['sendCommand']>>>()
+    vi.spyOn(client, 'sendCommand').mockReturnValue(response.promise)
+    let current = true
+    const login = realLogin(
+      client,
+      {
+        state: 0,
+        uin: '123456',
+        tgtgtKey: Buffer.alloc(16),
+        tempPassword: Buffer.alloc(16),
+        noPicSig: Buffer.alloc(16),
+      },
+      () => current,
+    )
+    const rejected = expect(login).rejects.toThrow('QR login attempt was superseded')
+    current = false
+    response.resolve({ seq: 1, retCode: 0, extraMsg: '', cmd: 'wtlogin.login', payload: Buffer.alloc(0) })
+    await rejected
+    expect(client.isLoggedIn).toBe(false)
+  })
+
+  it('does not delay disconnect callbacks when unauthenticated pushes keep arriving', async () => {
+    const protocol = new DirectQQProtocol(new Context())
+    protocol['directClient'] = client
+    protocol['bindDirectClientEvents'](client)
+    vi.spyOn(protocol as unknown as { ensureQrLoop(): void }, 'ensureQrLoop').mockImplementation(() => {})
+    const disconnected = vi.fn()
+    protocol.onDisconnect(10000, disconnected)
+    protocol['startDisconnectMonitoring']()
+    client['conn'].emit('packet', responseFrame(0, -10001, '', authMessage))
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersByTimeAsync(2000)
+      client['conn'].emit('packet', responseFrame(0, -10001, '', authMessage))
+    }
+    expect(disconnected).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/unit/qqProtocol/offlineNotifications.test.ts
+++ b/test/unit/qqProtocol/offlineNotifications.test.ts
@@ -1,0 +1,102 @@
+import { Context } from 'cordis'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { selfInfo } from '@/common/globalVars'
+import { EmailNotificationService } from '@/common/emailNotification'
+import { EmailConfigManager } from '@/common/emailConfig'
+import { MilkyAdapter } from '@/milky/adapter'
+
+vi.mock('@/common/emailConfig', () => ({
+  EmailConfigManager: class {
+    loadConfig = vi.fn(async () => ({}))
+    getConfig = vi.fn(() => ({ enabled: true }))
+  },
+}))
+
+vi.mock('@/common/emailService', () => ({
+  EmailService: class {
+    sendOfflineNotification = vi.fn(async () => ({ success: true }))
+  },
+}))
+
+describe('session expiration notifications', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    selfInfo.online = true
+    // Exercise the real notification handlers without reading config, watching files, or sending mail.
+    vi.spyOn(
+      EmailNotificationService.prototype as unknown as { initializeConfig(): Promise<void> },
+      'initializeConfig',
+    ).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it.each(['qq/session-expired', 'nt/kicked-offline'] as const)(
+    'sends the reason once and rearms after login for %s',
+    async (event) => {
+      const ctx = new Context()
+      const onDisconnect = vi.fn()
+      ctx.provide('qqProtocol', { onDisconnect, offDisconnect: vi.fn() })
+      const email = new EmailNotificationService(ctx)
+      const send = vi.mocked(email.getEmailService().sendOfflineNotification)
+      const reason = 'Test authentication failure'
+      const emitOffline = () =>
+        event === 'qq/session-expired'
+          ? ctx.parallel(event, reason)
+          : ctx.parallel(event, { tipsDesc: reason, tipsTitle: 'Offline', kickedType: 1001 })
+
+      selfInfo.online = false
+      await emitOffline()
+      expect(send).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ uin: '123456' }), reason)
+      await emitOffline()
+      onDisconnect.mock.calls[0][1](10000)
+      expect(send).toHaveBeenCalledTimes(1)
+
+      selfInfo.online = true
+      await vi.advanceTimersByTimeAsync(5000)
+      selfInfo.online = false
+      await emitOffline()
+      expect(send).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it('respects disabled email notifications', async () => {
+    const ctx = new Context()
+    ctx.provide('qqProtocol', { onDisconnect: vi.fn(), offDisconnect: vi.fn() })
+    const email = new EmailNotificationService(ctx)
+    vi.mocked(email.getConfigManager().getConfig).mockReturnValue({ enabled: false } as ReturnType<
+      EmailConfigManager['getConfig']
+    >)
+    selfInfo.online = false
+    await ctx.parallel('qq/session-expired', 'Test authentication failure')
+    expect(email.getEmailService().sendOfflineNotification).not.toHaveBeenCalled()
+  })
+
+  it.each(['qq/session-expired', 'nt/kicked-offline'] as const)(
+    'broadcasts the existing Milky bot_offline payload for %s',
+    async (event) => {
+      const ctx = new Context()
+      // Only event registration and serialization are needed; no HTTP server or webhook is started.
+      const http = { broadcast: vi.fn() }
+      const webhook = { broadcast: vi.fn() }
+      const adapter = Object.assign(Object.create(MilkyAdapter.prototype) as MilkyAdapter, {
+        ctx,
+        httpHandler: http,
+        webhookHandler: webhook,
+      })
+      adapter['setupEventListeners']()
+      const reason = 'Test authentication failure'
+      if (event === 'qq/session-expired') await ctx.parallel(event, reason)
+      else await ctx.parallel(event, { tipsDesc: reason, tipsTitle: 'Offline', kickedType: 1001 })
+
+      expect(http.broadcast).toHaveBeenCalledTimes(1)
+      const payload = JSON.parse(http.broadcast.mock.calls[0][0])
+      expect(payload).toMatchObject({ self_id: 123456, event_type: 'bot_offline', data: { reason } })
+      expect(webhook.broadcast).toHaveBeenCalledExactlyOnceWith(http.broadcast.mock.calls[0][0])
+    },
+  )
+})


### PR DESCRIPTION
## 问题与影响

LLBot Direct 模式下，QQ 服务端拒绝当前会话时，可以返回 `retCode=-10001`、`seq=0`、`cmd=""` 的 SSO 响应。原实现先按请求序号查找等待中的请求，因此这类无法匹配请求的鉴权错误会进入 push 分支，随后因命令为空而未被处理。

结果是：实际业务请求持续超时，QQ 消息停止上报，但 TCP 连接、连接级心跳和 OneBot WebSocket 仍可保持工作，`get_status` 也仍返回 `online=true`。使用者看到的是机器人长时间不响应，却没有明确的重新登录提示。

本 PR 在请求匹配前处理会话鉴权失败，立即使失效会话退出在线状态，并进入已有的二维码登录流程。

## 现场环境与脱敏说明

- 故障版本：LLBot `8.1.10`，Docker 部署，Direct 模式（原生签名 + TCP）。
- 下游：AstrBot，通过 OneBot v11 反向 WebSocket 接入。
- 故障期间 WebUI 和本地 OneBot 连接仍可访问；容器存活不能证明 QQ 会话有效。
- 以下时间统一为 **2026-09-06，Asia/Shanghai（UTC+8）**；抓包工具原先输出 UTC，展示时已换算。
- 原始日志仅节选与诊断有关的行。账号、UID、群号、昵称、IP、主机名及部署端口均删除或替换为 `<...>`。未附带消息正文、Authorization、会话凭据、密钥、二维码、配置文件或原始抓包文件。
- `seq=0`、错误码、命令名和超时时长属于定位问题所需的协议字段，予以保留。抓包解析结果与 LLBot 原生日志分开展示。

## 故障时间线与日志证据

| 时间 | 观察结果 |
| --- | --- |
| 16:07:59 | 首次记录到会话心跳 `SsoHeartBeat` 超时。 |
| 16:10:07 | 群历史查询相关请求开始记录 15 秒超时。 |
| 16:20:02 | 本次排查所见的最后一条 QQ 群消息上报；因此不能把首次心跳超时直接当作消息完全中断的时刻。 |
| 19:25:59 | 会话心跳仍在超时，故障持续数小时。 |
| 19:28 左右 | `get_status` 仍显示在线；绕过缓存查询群信息却在约 15 秒后失败。 |
| 19:39–19:42 | 抓包确认 TCP 双向传输仍在继续，并解析出服务端明确的鉴权失败响应；连接级 `Heartbeat.Alive` 仍成功。 |
| 19:46:15 | 手动重新扫码登录成功；后续只读群信息查询恢复成功。此恢复发生在安装本 PR 补丁之前。 |

### 1. LLBot 原生日志节选

以下日志只替换了部署地址与身份字段；中间无关行已省略：

```text
2026-09-06 16:07:59 [E] heartbeat [Heartbeat] Failed: Command trpc.qq_new_tech.status_svc.StatusService.SsoHeartBeat timed out after 5000ms
2026-09-06 16:10:07 [E] onebot11-adapter 发生错误 Error: Command OidbSvcTrpcTcp.0x88d_0 timed out after 15000ms
2026-09-06 16:20:02 [I] onebot11-adapter WebSocket 事件上报 ws://<ASTRBOT_HOST>:<ONEBOT_WS_PORT>/ws message.group
2026-09-06 19:25:59 [E] heartbeat [Heartbeat] Failed: Command trpc.qq_new_tech.status_svc.StatusService.SsoHeartBeat timed out after 5000ms
2026-09-06 19:46:15 [I] qq-protocol Login successful! UID: <REDACTED>, nick: <REDACTED>
```

单凭这些超时日志无法区分网络故障和会话鉴权失败，也不能证明早期每一次超时都由相同原因引起。鉴权失败的直接证据来自下面的响应解析。

### 2. 故障期间的 OneBot 只读探测

`get_status` 耗时约 0.013 秒，以下只保留状态字段：

```json
{
  "status": "ok",
  "retcode": 0,
  "data": { "online": true, "good": true }
}
```

随后对脱敏目标 `<GROUP_ID>` 调用 `get_group_info`，设置 `no_cache=true`，耗时约 15.307 秒，返回：

```json
{
  "status": "failed",
  "retcode": 200,
  "data": null,
  "message": "Command OidbSvcTrpcTcp.0xfe5_2 timed out after 15000ms",
  "wording": "Command OidbSvcTrpcTcp.0xfe5_2 timed out after 15000ms"
}
```

这里的 OneBot `retcode=200` 是业务 API 的失败结果，与下文 QQ SSO 层的 `retCode=-10001` 属于不同层级。

### 3. TCP 传输与 SSO 响应解析

诊断期间被动观察 LLBot 网络命名空间中的现有连接，并配合只读 API 请求；没有为抓包重启 LLBot。下面是去除地址和 TCP 序号后的传输节选：

```text
2026-09-06T19:39:00.567+08:00 LLBot -> QQ  payload_len=540  frame_len=540
2026-09-06T19:39:00.668+08:00 QQ -> LLBot  payload_len=136  frame_len=136
```

该片段证明 TCP 连接仍有双向数据交换，不能单独证明业务请求成功，也不能仅凭时序认定它对应哪一个业务命令。

下面是**抓包后按协议解析得到的字段，不是 LLBot 原有日志**。保留了长度、协议版本、加密类型、错误码及命令；正常心跳的非零序号替换为占位符：

```json
{
  "at": "2026-09-06T19:41:44.710+08:00",
  "len": 136,
  "version": 12,
  "encryption": 2,
  "head_len": 89,
  "seq": 0,
  "retCode": -10001,
  "extraMsg": "身份验证失败，请你重新登录。(s20)",
  "cmd": ""
}
```

```json
{
  "at": "2026-09-06T19:41:57.502+08:00",
  "len": 89,
  "version": 13,
  "encryption": 0,
  "head_len": 57,
  "seq": "<NONZERO_SEQ>",
  "retCode": 0,
  "extraMsg": "",
  "cmd": "Heartbeat.Alive"
}
```

这说明服务端已经拒绝当前会话，但连接级存活检测仍然成功。`Heartbeat.Alive` 与需要会话鉴权的 `SsoHeartBeat` 不能互相替代。

能够确认的是**当前凭据被服务端判定为无效，以及 LLBot 漏处理了该响应**。仅凭现有证据无法确定服务端为何使凭据失效，例如自然到期或主动撤销；本修复不依赖任何假定的固定有效期。

## 源码中的漏处理路径

1. `DirectProtocolClient.handlePacket()` 原先先执行 `pendingPackets.get(parsed.seq)`，仅在匹配到请求后检查错误码。
2. 现场响应的 `seq=0` 无法匹配等待中的请求，因此被作为 push 发出；真正的请求仍等待到 5 秒或 15 秒超时。
3. `DirectQQProtocol` 转交 push 时只保留命令和载荷，没有将 `retCode` / `extraMsg` 转为会话失效事件；空命令也没有对应的 dispatcher 处理分支。
4. 会话心跳失败只记日志，连接本身又未断开，因此已保存的会话和在线状态未被清除。`get_status` 继续读取旧的 `selfInfo.online`，不能反映这次鉴权失败。

## 修复后的行为

- 在请求序号匹配之前处理 `retCode=-10001`，同时覆盖可匹配和无法匹配请求的鉴权失败。
- 清除当前会话，以明确的鉴权错误拒绝所有等待中的请求，并清理相关计时器。
- 检查异步签名期间会话是否发生变化，阻止已失效会话对应的命令继续发送。
- 将账号标记为离线，停止会话心跳和待执行的重连；仅删除被拒绝账号的保存会话，保留设备身份和原生客户端。
- 重置旧二维码及轮询状态，进入已有的二维码登录流程；此前已在线时发送协议断开事件，并通知邮件服务及 Milky 消费者。
- 二维码登录收尾携带本轮 `qrPollToken`，在查询 UIN、登录请求和上线注册等异步步骤后重新校验；底层登录响应在安装凭据前也校验该标记。手动登出同样取消旧流程。
- 保存会话的时机移到上线注册成功且当前会话仍有效之后；旧流程不能启动心跳、重新标记在线、覆盖登录错误，或清除后续新登录的会话。保存会话恢复路径的注册步骤也具有相同保护。
- 异步补查昵称时校验登录轮次与会话，防止旧结果覆盖新账号状态。

二维码登录仍需要使用者扫码确认。此次改动处理的是明确的鉴权失败；普通业务错误和普通传输断开继续沿用现有逻辑。

## 原有掉线处理与本次通知衔接

此前的 `protocol/disconnect` 监听器只记录断开日志，并不直接推送掉线通知。已核对的其他处理如下：

| 原有处理 | 触发方式 | 本次修复如何衔接 |
| --- | --- | --- |
| 掉线邮件 | `nt/kicked-offline` 时立即通知；协议持续异常达到 10 秒时，5 秒巡检触发断线回调。 | 已在线会话被明确拒绝时发出 `qq/session-expired`，复用邮件服务的 `onOffline(reason)`，附带实际鉴权失败原因，遵守已有启用开关、通知去重及重新登录后复位逻辑。 |
| Milky 离线推送 | `nt/kicked-offline` 转换成 `bot_offline`，通过既有 HTTP/WebSocket 与 webhook 广播路径分发。 | 监听 `qq/session-expired` 并发送相同的 `bot_offline` 事件结构，`data.reason` 为鉴权失败原因。 |
| Direct 协议恢复 | 被踢下线会停止心跳并断开连接；特定异地登录代码 `1001` 还会清除设备身份。 | 会话鉴权失败继续使用本 PR 的清理和二维码恢复流程，保留设备身份及原生客户端。通知使用单独事件，避免误触发 KickNT 的断连或设备清理。 |

只有此前已上报在线的账号才发送即时会话失效通知；首次登录注册失败不会被误报为已在线机器人掉线。会话清除后，仍收到的未鉴权 push 不再刷新 `lastConnectedTime`，避免反复错误包推迟原有断线超时回调。

## 自动评审问题的处理

已处理 [Sourcery 指出的登录收尾竞态](https://github.com/LLOneBot/LuckyLilliaBot/pull/856#discussion_r3943920876)，对应提交 `bedb57f8`。

复现过程是：让二维码登录的 `registerOnline()` 暂停，注入 `retCode=-10001` 使当前会话失效，再让旧注册请求完成。原 PR 提交 `7b6eec55` 会把 `selfInfo.online` 重新写为 `true`。另一个场景是旧注册请求稍后失败，原实现会清除已经替换的新会话。现已对成功和异常路径同时增加登录轮次与会话校验，并覆盖保存会话恢复路径中的同类竞态。

## 验证结果与边界

- `npm test`：**17 个测试文件、175 项测试通过**；本 PR 共包含 24 项相关回归测试，其中本次评审后补充 15 项。
- 协议回归覆盖：`seq=0` 与匹配序号的鉴权失败、等待请求清理、普通错误/推送/断线、签名中失效、二维码登录各异步阶段失效、保存会话恢复的迟到成功/失败、保护替换会话、主动登出取消、正常扫码登录，以及未鉴权数据持续到达时的超时回调。
- 通知回归覆盖：新会话失效事件与原 KickNT 事件均能携带原因触发邮件和 Milky；邮件禁用时不发送；成功发送后的重复通知被现有逻辑抑制，并在重新登录后按现有规则复位。
- 将相关源码临时恢复为评审时的 `7b6eec55`，选取上述竞态、超时回调和通知场景，得到 **7 项预期失败**；恢复本次补丁后全部通过。
- 使用同一条无法匹配请求的鉴权失败回归测试检查未修改的上游代码，能够复现失败；应用补丁后通过。
- `npm run build`：通过。
- 两个回归测试文件的 Prettier 检查及 `git diff --check`：通过。
- `npm run check`：遇到已有的类型错误，已在基线提交 `1cadea38` 上复现相同结果：

```text
src/ntqqapi/helper/messageBuilding.ts(74,9): error TS2322: Type 'number | undefined' is not assignable to type 'string | undefined'.
  Type 'number' is not assignable to type 'string'.
```

本地验证使用 Node.js `26.8.1`。回归测试使用合成协议帧，并模拟网络、签名、会话存储、邮件发送和 Milky 广播端点，没有把真实账号、凭据或抓包载荷写入测试，也没有向真实收件人或 webhook 发送测试通知。**补丁尚未部署到在线 QQ 实例进行端到端验证**；上面的重新登录成功日志仅证明现场手动恢复，不能作为补丁线上验证结果。



## Sourcery 摘要

通过使过期会话失效，并在未匹配的响应被误判为推送消息之前发起二维码重新登录，恢复 QQ 认证失败后的可靠恢复能力。

错误修复：
- 在请求匹配之前处理 QQ 会话认证失败，包括无序响应，从而拒绝无效会话，避免其无限期超时。
- 当 QQ 服务器报告认证失败时，自动将账号标记为离线，清除被拒绝的会话，并重新启动现有的二维码登录流程。

增强功能：
- 防止在会话失效后异步签名完成时发送命令。

测试：
- 增加回归测试，覆盖已匹配和未匹配的认证失败、待处理请求清理、签名期间会话失效、二维码恢复，以及普通错误、推送和传输关闭行为的保留。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过使过期会话失效并提示通过二维码重新认证，恢复从 QQ 身份验证失败中可靠恢复的能力。

错误修复：
- 在请求匹配之前处理 QQ 会话身份验证失败，包括未按序响应，从而拒绝无效会话，而不是让请求超时。
- 自动将被拒绝的账号标记为离线，仅移除其无效的已保存会话，并重新启动二维码登录流程。
- 防止在底层会话已失效或被替代后，命令和登录完成操作继续生效。

改进：
- 当在线 QQ 会话过期时通知电子邮件和 Milky 集成，同时保留现有的传输断开行为。

测试：
- 增加回归测试，覆盖匹配和未匹配的身份验证失败、待处理请求清理、过期的异步签名和登录流程、二维码恢复、通知，以及现有普通错误、推送和断开行为的保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore reliable recovery from QQ authentication failures by invalidating stale sessions and prompting QR-code reauthentication.

Bug Fixes:
- Handle QQ session authentication failures before request matching, including unsequenced responses, so invalid sessions are rejected instead of leaving requests to time out.
- Automatically mark rejected accounts offline, remove only their invalid saved session, and restart the QR-code login flow.
- Prevent commands and login completions from applying after the underlying session has been invalidated or superseded.

Enhancements:
- Notify email and Milky integrations when an online QQ session expires while preserving existing transport-disconnect behavior.

Tests:
- Add regression coverage for matched and unmatched authentication failures, pending-request cleanup, stale asynchronous signing and login flows, QR recovery, notifications, and preserved ordinary error, push, and disconnect behavior.

</details>

</details>